### PR TITLE
Limit pytest to versions < 4.0 (fixtures can’t be functions anymore)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,7 @@ setup(
         'scipy>=0.17',
         'openpyxl>=2.4'
     ],
-    tests_require=['pytest'],
+    tests_require=['pytest<4.0'],
     packages=find_packages(),
     package_data={PACKAGENAME: ['prd_data/HST/*/*.dat',
                                 'prd_data/JWST/*/*/*/*.xlsx',


### PR DESCRIPTION
The Travis build is currently failing because of this.